### PR TITLE
Dual Hash Reworked

### DIFF
--- a/g6k/algorithms/bkz.py
+++ b/g6k/algorithms/bkz.py
@@ -7,6 +7,12 @@ from .pump import pump
 from .workout import workout
 import six
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
+
 def dim4free_wrapper(dim4free_fun, blocksize):
     """
     Deals with correct dim4free choices for edge cases when non default

--- a/g6k/decl.pxd
+++ b/g6k/decl.pxd
@@ -232,7 +232,7 @@ cdef extern from "../kernel/siever.h" nogil:
         void load_gso(unsigned int full_n, double* mu)
 
         # Local setup methods:
-        void reset_dual_vecs( float* dual_vecs_ptr, unsigned int dh_vecs, unsigned int dh_dim, float conv_ratio, unsigned int target_index ) 
+        void reset_dual_vecs( float* dual_vecs_ptr, unsigned int dh_vecs, unsigned int dh_dim, float conv_ratio, unsigned int target_index, float max_hbound ) 
         void initialize_local(unsigned int ll_, unsigned int l_, unsigned int r_)
         void extend_left(unsigned int lp)
         void shrink_left(unsigned int lp)

--- a/g6k/siever.pyx
+++ b/g6k/siever.pyx
@@ -21,7 +21,7 @@ import numpy as npp
 from numpy.linalg import inv, cond
 cimport numpy as np
 from fpylll import LLL, GSO, IntegerMatrix, Enumeration
-from math import ceil, floor, gamma
+from math import ceil, floor, lgamma, gamma
 
 from decl cimport CompressedEntry, Entry
 from decl cimport show_cpu_stats
@@ -1165,7 +1165,7 @@ cdef class Siever(object):
         # TODO: sample dummy vecs as they will be overwritten
         self.resize_db(N, 0)
 
-        self.reset_dual_vecs(256)
+        self.reset_dual_vecs(128)
 
         sig_on()
         self._core.gpu_sieve()
@@ -1330,7 +1330,7 @@ cdef class Siever(object):
 
             # greedy improvement
             if dual_hash_vecs_construct > dual_hash_vecs:
-                for t in xrange(1):
+                for t in xrange(2):
                     sub = npp.copy(dual_vecs)
                     for i in xrange(dual_vecs_yr.shape[0]):
                         g = sub.transpose().dot(sub)
@@ -1358,20 +1358,25 @@ cdef class Siever(object):
             #print(self.l-dual_hash_d4f, self.l, self.r, gaussian_heuristic( self.M.r()[self.l-dual_hash_d4f:self.r] ), gaussian_heuristic( self.M.r()[self.l:self.r]))
 
             tr = npp.trace(gram)
-            dt = npp.det(gram)
+            logdt = npp.linalg.slogdet(gram)[1]
+            dt_norm = npp.exp(logdt/k)
             conv_ratio = 0.
             if( length_bound > 0 ):
                 conv_ratio = tr / k
 
             # compute max_hbound to keep filter acceptance low enough
-            max_acceptance = 1e-6
-            max_hbound_unpreserved = (max_acceptance/npp.pi**(dual_hash_vecs/2.) / gamma(dual_hash_vecs/2.+1))**(2./dual_hash_vecs)
-            max_bdd_preserved = (max_acceptance**2 * dt)**(1./k) * k / tr
+            max_acceptance = self.params.dh_acceptance;
+            log_max_acceptance = npp.log(max_acceptance)
+            log_max_hbound_unpreserved = 2./dual_hash_vecs * (log_max_acceptance - dual_hash_vecs/2. * npp.log(npp.pi) + lgamma(dual_hash_vecs/2.+1))
+            max_hbound_unpreserved = npp.exp(log_max_hbound_unpreserved)
+            max_bdd_preserved = (max_acceptance)**(2./k) * dt_norm * k / tr
             max_bound = max_bdd_preserved * gaussian_heuristic(self.M.r()[self.l-k:self.l])
             max_hbound_preserved = max_bound * conv_ratio
-            print("max hbounds:", max_hbound_preserved, max_hbound_unpreserved)
             max_hbound = min(max_hbound_preserved, max_hbound_unpreserved)
-            
+           
+            # preserved acceptance ratio
+            #p_ar = (max_hbound / max_hbound_preserved)**(k/2.) * max_acceptance
+            #print("max hbounds:", max_hbound_preserved, max_hbound_unpreserved, conv_ratio * length_bound, p_ar)
             for i in xrange(dual_hash_vecs):
                 for j in xrange(k):
                     dual_vecs[i,j] = dual_vecs[i,j] * self.M.r()[hash_start+j]**0.5

--- a/g6k/siever.pyx
+++ b/g6k/siever.pyx
@@ -1330,7 +1330,7 @@ cdef class Siever(object):
 
             # greedy improvement
             if dual_hash_vecs_construct > dual_hash_vecs:
-                for t in xrange(3):
+                for t in xrange(1):
                     sub = npp.copy(dual_vecs)
                     for i in xrange(dual_vecs_yr.shape[0]):
                         g = sub.transpose().dot(sub)
@@ -1355,9 +1355,11 @@ cdef class Siever(object):
             sub = npp.copy(dual_vecs)
             gram = sub.transpose().dot(sub)
             
+            #print(self.l-dual_hash_d4f, self.l, self.r, gaussian_heuristic( self.M.r()[self.l-dual_hash_d4f:self.r] ), gaussian_heuristic( self.M.r()[self.l:self.r]))
+
             conv_ratio = 0.
             if( length_bound > 0 ):
-                conv_ratio = npp.trace(gram) / dual_hash_d4f
+                conv_ratio = npp.trace(gram) / k
         
         for i in xrange(dual_hash_vecs):
             for j in xrange(k):

--- a/g6k/siever_params.pyx
+++ b/g6k/siever_params.pyx
@@ -78,6 +78,7 @@ cdef class SieverParams(object):
         "dual_mode",
         "dh_dim4free",
         "dh_min",
+        "dh_acceptance"
 ]
 
     def __init__(self, **kwds):
@@ -133,6 +134,8 @@ cdef class SieverParams(object):
             kwds["dh_dim4free"] = 32
         if "dh_min" not in kwds:
             kwds["dh_min"] = 90
+        if "dh_acceptance" not in kwds:
+            kwds["dh_acceptance"] = 1e-5
         if "bdgl_bucket_size" not in kwds:
             kwds["bdgl_bucket_size"] = 16*1024
         if "gpu_bucketer" not in kwds:

--- a/g6k/siever_params.pyx
+++ b/g6k/siever_params.pyx
@@ -119,9 +119,9 @@ cdef class SieverParams(object):
         if "streams_per_thread" not in kwds:
             kwds["streams_per_thread"] = 1
         if "dh_dim" not in kwds:
-            kwds["dh_dim"] = 16
+            kwds["dh_dim"] = 20
         if "dh_vecs" not in kwds:
-            kwds["dh_vecs"] = 0
+            kwds["dh_vecs"] = 32
         if "dh_bucket_ratio" not in kwds:
             kwds["dh_bucket_ratio"] = 0.5
         if "multi_bucket" not in kwds:

--- a/kernel/siever.h
+++ b/kernel/siever.h
@@ -301,13 +301,14 @@ class DualHashes
 
     public:
         int acceptance_radius;
+        float max_hbound = 0.;
         bool initialized = false;
 
         explicit DualHashes(){}
         
         inline void disable();
         inline void reset_dual_vecs(Siever const &siever, 
-                const std::vector<std::vector<LFT>> dual_vecs, float conv_ratio, unsigned int target_index);
+                const std::vector<std::vector<LFT>> dual_vecs, float conv_ratio, unsigned int target_index, float max_hbound);
         inline void update_dh_bound( Siever const &siever, float lenbound ); 
         inline int radius_for_ratio( const double x ) const; 
         inline void reset_acceptance_radius( const double x);

--- a/kernel/siever.h
+++ b/kernel/siever.h
@@ -547,7 +547,7 @@ public:
     SieverParams get_params(); // implemented in params.cpp
     
     // Transfer dual vecs from python layer to DualHash
-    void reset_dual_vecs( LFT* dual_vecs_ptr, size_t nr_dual_vecs, size_t dim_dual, LFT conv_ratio, unsigned int target_index ) 
+    void reset_dual_vecs( LFT* dual_vecs_ptr, size_t nr_dual_vecs, size_t dim_dual, LFT conv_ratio, unsigned int target_index, float max_hbound ) 
     {
         if( nr_dual_vecs == 0 ) {
             dual_hashes.disable();
@@ -556,7 +556,7 @@ public:
             std::vector<std::vector<LFT>> dual_vecs(nr_dual_vecs, std::vector<LFT>(dim_dual, 0.));
             for( size_t i = 0; i < nr_dual_vecs; ++i )
                 std::copy( dual_vecs_ptr + i * dim_dual, dual_vecs_ptr + (i+1) * dim_dual, dual_vecs[i].begin() );
-            dual_hashes.reset_dual_vecs(*this, dual_vecs, conv_ratio, target_index );
+            dual_hashes.reset_dual_vecs(*this, dual_vecs, conv_ratio, target_index, max_hbound );
        
 
             if( !NOYR ) {

--- a/kernel/simhash.inl
+++ b/kernel/simhash.inl
@@ -92,9 +92,10 @@ void DualHashes::disable() {
     acceptance_radius = 0;
 }
 
-void DualHashes::reset_dual_vecs(Siever const &siever, const std::vector<std::vector<LFT>> new_dual_vecs, float _conv_ratio, unsigned int _target_index) {
+void DualHashes::reset_dual_vecs(Siever const &siever, const std::vector<std::vector<LFT>> new_dual_vecs, float _conv_ratio, unsigned int _target_index, float _max_hbound) {
     conv_ratio = _conv_ratio;
     target_index = _target_index;
+    max_hbound = _max_hbound;
 
     nr_vecs = new_dual_vecs.size();
     assert( nr_vecs > 0 );
@@ -131,9 +132,10 @@ inline void DualHashes::update_dh_bound( Siever const &siever, float lenbound ) 
         float bound = bound_left * k / (siever.l-target_index);
         float dual_bound = conv_ratio * bound;
         dual_bound = std::max(dual_bound, float(0.));
+        dual_bound = std::min(dual_bound, max_hbound);
         acceptance_radius = int(256*256*dual_bound);
         
-        acceptance_radius = std::min(radius_for_ratio(0.000003), acceptance_radius);
+        //acceptance_radius = std::min(radius_for_ratio(0.000003), acceptance_radius);
 
         //std::cout << bound << " " << lenbound << " " << siever.gh << " " << dual_bound << " " << get_acceptance_ratio() << std::endl;
     }

--- a/kernel/simhash.inl
+++ b/kernel/simhash.inl
@@ -134,10 +134,6 @@ inline void DualHashes::update_dh_bound( Siever const &siever, float lenbound ) 
         dual_bound = std::max(dual_bound, float(0.));
         dual_bound = std::min(dual_bound, max_hbound);
         acceptance_radius = int(256*256*dual_bound);
-        
-        //acceptance_radius = std::min(radius_for_ratio(0.000003), acceptance_radius);
-
-        //std::cout << bound << " " << lenbound << " " << siever.gh << " " << dual_bound << " " << get_acceptance_ratio() << std::endl;
     }
 }
 

--- a/kernel/simhash.inl
+++ b/kernel/simhash.inl
@@ -115,7 +115,7 @@ void DualHashes::reset_dual_vecs(Siever const &siever, const std::vector<std::ve
         }
     }
 
-    ball_volume = std::pow(M_PI, k/2.) / tgamma( k/2. + 1);
+    ball_volume = std::pow(M_PI, nr_vecs/2.) / tgamma( nr_vecs/2. + 1);
 
     tests = 0;
     tests_passed = 0;
@@ -126,17 +126,22 @@ void DualHashes::reset_dual_vecs(Siever const &siever, const std::vector<std::ve
 
 inline void DualHashes::update_dh_bound( Siever const &siever, float lenbound ) {
     acceptance_radius = 0;
-    if(nr_vecs > 0 ) {
-        float bound = siever.get_lift_bound( target_index ) - lenbound * siever.gh;
+    if(nr_vecs > 0 and k > 0) {
+        float bound_left = siever.get_lift_bound( target_index ) - lenbound * siever.gh;
+        float bound = bound_left * k / (siever.l-target_index);
         float dual_bound = conv_ratio * bound;
         dual_bound = std::max(dual_bound, float(0.));
-        acceptance_radius = size_t(256*256*dual_bound);
+        acceptance_radius = int(256*256*dual_bound);
+        
+        acceptance_radius = std::min(radius_for_ratio(0.000003), acceptance_radius);
+
+        //std::cout << bound << " " << lenbound << " " << siever.gh << " " << dual_bound << " " << get_acceptance_ratio() << std::endl;
     }
 }
 
 // squared radius
 inline int DualHashes::radius_for_ratio( const double x ) const {
-   return int(256*256 * nr_vecs / double(k) * std::pow((x/ball_volume), 2. / k)); 
+   return int(256*256 * std::pow((x/ball_volume), 2. / nr_vecs)); 
 }
 
 inline void DualHashes::reset_acceptance_radius( const double x) {
@@ -144,7 +149,7 @@ inline void DualHashes::reset_acceptance_radius( const double x) {
 }
 
 inline double DualHashes::get_acceptance_ratio() {
-    return ball_volume * std::pow(double(acceptance_radius)/(256*256*nr_vecs/double(k)), k/2.);
+    return ball_volume * std::pow(double(acceptance_radius)/(256*256), nr_vecs/2.);
 }
 
 inline DualHashVector DualHashes::compress(std::array<LFT, OTF_LIFT_HELPER_DIM> const &v) const {


### PR DESCRIPTION
New dual hash defaults, and one can now pass a --dh_acceptance (default: 1e-5), which limits the acceptance ratio of the dual hash filter to at most that by sensibly limiting the dual hash bound based on the other parameters.