### PR TITLE
Continue BKZ even if we suspect SVP solution

### DIFF
--- a/lwe_challenge.py
+++ b/lwe_challenge.py
@@ -200,10 +200,10 @@ def lwe_kernel(arg0, params=None, seed=None):
             expo = 0.292
             svp_Tmax = svp_bkz_time_factor * T_BKZ
 
-            def attainable_SVP_dim(T_BKZ):
+            def attainable_SVP_dim(T_svp):
                 # solve max d s.t. 2^{expo * d} / param.threads <= svp_Tmax
                 return int(58+6 + (1./expo) *
-                           log(svp_Tmax * params.threads)/log(2.))
+                           log(T_svp * params.threads)/log(2.))
 
             def expected_successful_SVP_dim(rr=None):
                 if rr is None:
@@ -215,7 +215,7 @@ def lwe_kernel(arg0, params=None, seed=None):
                 return n_expected
 
             # given current state of basis
-            current_n_max = attainable_SVP_dim(T_BKZ)
+            current_n_max = attainable_SVP_dim(svp_Tmax)
             current_n_expected = expected_successful_SVP_dim()
 
             print("Without otf, would expect solution at pump-%d. n_max=%d in the given time." % (current_n_expected, current_n_max)) # noqa


### PR DESCRIPTION
Simulates the next couple of tours of BKZ, even when we expect to be able to attain an SVP dimension that solves the instance. This captures the cases where the decrease in required SVP dimension saves more time than the subsequent BKZ tours.

The next three BKZ tours are simulated using fpylll's built in simulator for ease, and the time required for these tours are calculated as a function of the time taken for most recent completed tour. It is then checked where a solution is likely to appear, and whether this saves enough time to justify these further tours.

A new factor passed via --lwe/favour-memory-factor determines how much weight we place on reducing the maximum SVP dim at the cost of further BKZ tours. Greater than 1 should reduce memory consumption at the cost of time.