### PR TITLE
fixing estimation bug for small n and adding a lift_slack parameter t…

### DIFF
--- a/g6k/utils/lwe_estimation.py
+++ b/g6k/utils/lwe_estimation.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-
 from math import e, lgamma, log, pi
 
 from fpylll import BKZ as fplll_bkz, GSO, IntegerMatrix, LLL
@@ -85,6 +84,9 @@ def log_gh_svp_q(d, delta, eta, n, q):
     # b_0, ..., b_q_index
     q_index = slope_begin - 1 if slope_begin > 0 else None
 
+    # makes no difference and assumption that q vectors remain is false
+    q_index = None
+
     if q_index is None:
         # can calculate as standard using rhf estimate for b_0 and GSA
         return log_gh_svp(d, delta, eta, n, q)
@@ -166,7 +168,7 @@ def decoupler(n, stddev, q, decouple):
     """
     params = []
 
-    ms = range(4*n+1)
+    ms = range(6*n+1, 295)
 
     for m in ms:
         beta_bound = min(m+1, 120+default_dim4free_fun(120))
@@ -180,8 +182,9 @@ def decoupler(n, stddev, q, decouple):
 
             for svp_dim in svp_dims:
                 d = m + 1
-                rhs = log_gh_svp_q(d, delta, svp_dim, n, q)
-                if rhs - log(stddev) - log(svp_dim)/2. >= 0:
+                rhs = log_gh_svp(d, delta, svp_dim, n, q)
+                # rhs = log_gh_svp_q(d, delta, svp_dim, n, q)
+                if rhs - log(stddev) - log(svp_dim)/2. > 0:
                     params.append([bkz_block_size, svp_dim, m+1])
 
     return params

--- a/lwe_challenge.py
+++ b/lwe_challenge.py
@@ -245,6 +245,15 @@ def lwe_kernel(arg0, params=None, seed=None):
                 sys.stdout.flush()
                 raise ValueError("llb < 0")
 
+            # llb is kappa for pump, so the point to which solutions are lifted
+            # lift_slack attempts to ensure we do not miss solution purely for
+            # not lifting enough. Note that while this increases beta = d-llb
+            # it increases dim4free f by the same amount, so the only extra
+            # cost incurred is from more lifting
+
+            lift_slack = 3
+            llb = max(0, llb-lift_slack)
+
             f = max(d-llb-n_expected, 0)
             if verbose:
                 print( "Starting svp pump_{%d, %d, %d}, n_max = %d, Tmax= %.2f sec" % (llb, d-llb, f, n_max, svp_Tmax) ) # noqa


### PR DESCRIPTION
Allow larger number of samples to be searched (previous bound of 4*n too small for n = 40 cases). Also added lift_slack parameter. The sieve will functionally have the same maximum sieving context, despite the blocksize increasing, because the dimensions for free increase to match. However, this does mean that short vectors in a given sieve are lifted more dimensions.